### PR TITLE
Update Eyeglass to ^3.0.0 and Sass to ^1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 		"url": "https://github.com/ernieayala/teq-tonic/issues"
 	},
 	"dependencies": {
-		"eyeglass": "1.5.0",
-		"sass": "1.18.0"
+		"eyeglass": "^3.0.0",
+		"sass": "^1.52.3"
 	},
 	"description": "A neat Sass tool set",
 	"eyeglass": {
@@ -35,5 +35,5 @@
 	},
 	"style": "core/_teq-tonic.scss",
 	"title": "Teq-Tonic Tools",
-	"version": "1.4.2"
+	"version": "1.4.3"
 }


### PR DESCRIPTION
`node-sass` is deprecated (see [this post](https://sass-lang.com/blog/libsass-is-deprecated) and [this issue](https://github.com/nodejs/node-gyp/issues/2572)) which prevents dependencies from being installed. Since https://github.com/ernieayala/ernies-modern-layout depends on `teq-tonic`, it causes the same `node-gyp` installation failure.

I have verified that deps install correctly, but let me know if you would prefer a different semver for this. Additionally, I'm not a strong JS/frontend person--is there a good way to verify these changes? Dart Sass should have the same API.